### PR TITLE
Added a method that explicitly initializes statics

### DIFF
--- a/SteamManager.cs
+++ b/SteamManager.cs
@@ -48,6 +48,16 @@ public class SteamManager : MonoBehaviour {
 		Debug.LogWarning(pchDebugText);
 	}
 
+#if UNITY_VERSION_2019_3_OR_NEWER
+	// In case of disabled Domain Reload, reset static members before entering Play Mode.
+	[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+	private static void InitOnPlayMode()
+	{
+		s_EverInitialized = false;
+		s_Instance = null;
+	}
+#endif
+
 	protected virtual void Awake() {
 		// Only one instance of SteamManager at a time!
 		if (s_instance != null) {


### PR DESCRIPTION
Disabling Domain Reload is [an experimental feature since Unity 2019.3](https://blogs.unity3d.com/2019/11/05/enter-play-mode-faster-in-unity-2019-3/) which helps you speed up playtesting. This feature causes static members to keep their values between runs without code changes in between, which can be problematic sometimes.

Before this commit, SteamManager would get confused when such runs occurred because `s_EverInitialized` did not reset to `false` at the start of each play mode, as described here.

https://github.com/rlabrecque/Steamworks.NET/issues/362

This PR adds a method that automatically resets the value of the static members in `SteamManager` to their default. They are disabled for Unity versions before 2019.x, since it uses values not documented in such releases.