### PR TITLE
Hotfix for wrong version directive

### DIFF
--- a/SteamManager.cs
+++ b/SteamManager.cs
@@ -48,7 +48,7 @@ public class SteamManager : MonoBehaviour {
 		Debug.LogWarning(pchDebugText);
 	}
 
-#if UNITY_VERSION_2019_3_OR_NEWER
+#if UNITY_2019_3_OR_NEWER
 	// In case of disabled Domain Reload, reset static members before entering Play Mode.
 	[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
 	private static void InitOnPlayMode()


### PR DESCRIPTION
This is a hotfix for the issue raised here: https://github.com/rlabrecque/Steamworks.NET/issues/362#issuecomment-645143263.  
When the previous PR #2 added protection for disabled Domain Reload, the version directive was misspelled. This PR fixes the typo, and this should work because now my IDE is showing that the directive is indeed valid and resetting procedures is now reliably executed.

Merging this PR should also close rlabrecque/Steamworks.NET#362.