### PR TITLE
Adds MonoPInvokeCallback Attribute to SteamAPIDebugTextHook

### DIFF
--- a/SteamManager.cs
+++ b/SteamManager.cs
@@ -3,7 +3,7 @@
 // Where that dedication is not recognized you are granted a perpetual,
 // irrevocable license to copy and modify this file as you see fit.
 //
-// Version: 1.0.10
+// Version: 1.0.11
 
 #if UNITY_ANDROID || UNITY_IOS || UNITY_TIZEN || UNITY_TVOS || UNITY_WEBGL || UNITY_WSA || UNITY_PS4 || UNITY_WII || UNITY_XBOXONE || UNITY_SWITCH
 #define DISABLESTEAMWORKS

--- a/SteamManager.cs
+++ b/SteamManager.cs
@@ -44,6 +44,8 @@ public class SteamManager : MonoBehaviour {
 	}
 
 	protected SteamAPIWarningMessageHook_t m_SteamAPIWarningMessageHook;
+
+	[AOT.MonoPInvokeCallback(typeof(SteamAPIWarningMessageHook_t))]
 	protected static void SteamAPIDebugTextHook(int nSeverity, System.Text.StringBuilder pchDebugText) {
 		Debug.LogWarning(pchDebugText);
 	}

--- a/SteamManager.cs
+++ b/SteamManager.cs
@@ -3,7 +3,7 @@
 // Where that dedication is not recognized you are granted a perpetual,
 // irrevocable license to copy and modify this file as you see fit.
 //
-// Version: 1.0.9
+// Version: 1.0.10
 
 #if UNITY_ANDROID || UNITY_IOS || UNITY_TIZEN || UNITY_TVOS || UNITY_WEBGL || UNITY_WSA || UNITY_PS4 || UNITY_WII || UNITY_XBOXONE || UNITY_SWITCH
 #define DISABLESTEAMWORKS
@@ -54,7 +54,7 @@ public class SteamManager : MonoBehaviour {
 	private static void InitOnPlayMode()
 	{
 		s_EverInitialized = false;
-		s_Instance = null;
+		s_instance = null;
 	}
 #endif
 


### PR DESCRIPTION
Per [tomjohnstone's comment](https://github.com/rlabrecque/Steamworks.NET/issues/227#issuecomment-389302226) in [Unity 2018.1 and IL2CPP](https://github.com/rlabrecque/Steamworks.NET/issues/227), the `MonoPInvokeCallback `attribute should be added to `SteamAPIDebugTextHook`.